### PR TITLE
Fixes missing event emitter property in Terminal constructor for Windows

### DIFF
--- a/lib/pty_win.js
+++ b/lib/pty_win.js
@@ -6,6 +6,7 @@
 var net = require('net');
 var path = require('path');
 var extend = require('extend');
+var EventEmitter = require('events').EventEmitter;
 var inherits = require('util').inherits;
 var BaseTerminal = require('./pty').Terminal;
 var pty = require('../build/Release/pty.node');
@@ -116,6 +117,9 @@ function Terminal(file, args, opt) {
   opt = opt || {};
 
   env = extend({}, opt.env);
+
+  // for 'close'
+  this._internalee = new EventEmitter;
 
   cols = opt.cols || 80;
   rows = opt.rows || 30;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pty.js-next",
   "description": "Pseudo terminals for node.",
   "author": "Christopher Jeffrey",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "main": "./index.js",
   "repository": "git://github.com/chjj/pty.js.git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pty.js",
+  "name": "pty.js-next",
   "description": "Pseudo terminals for node.",
   "author": "Christopher Jeffrey",
   "version": "0.3.1",


### PR DESCRIPTION
I'm having problems with missing this._internalee for Terminal instances. This is a solution.
