### PR TITLE
Fix returning a result code from a pty on Mac

### DIFF
--- a/lib/pty.js
+++ b/lib/pty.js
@@ -135,10 +135,10 @@ function Terminal(file, args, opt) {
     // close
     self._close();
     // EIO on exit from fs.ReadStream:
-    if (!self._emittedExit) {
-      self._emittedExit = true;
+    if (!self._emittedClose) {
+      self._emittedClose = true;
       Terminal.total--;
-      self.emit('exit', null);
+      self.emit('close');
     }
 
     // EIO, happens when someone closes our child
@@ -172,14 +172,12 @@ function Terminal(file, args, opt) {
 
   // XXX This never gets emitted with v0.12.0
   this.socket.on('close', function() {
-    if (self._emittedExit)
-      return;
-
-    self._emittedExit = true;
+    if (self._emittedClose) return;
+    self._emittedClose = true;
     Terminal.total--;
 
     self._close();
-    self.emit('exit', null);
+    self.emit('close');
   });
 
   env = null;


### PR DESCRIPTION
In my tests on Mac, the result code always comes back as undefined.

```
var pty = require('ptyw.js')

var p = pty.spawn('bash', ['-c', 'false'])

p.once('exit', function(code, signal) {
    console.log('code', code);
    console.log('signal', signal);
});
```

We get the following output:

```
joerick@joerick ~/Desktop/ptywtest> node index.js
code null
signal undefined
```

This patch reverts some changes that allow the Terminal to call the exit handler once the `onexit` callback has fired, so the `code` and `signal` values are known (this may be before or after the Socket has closed).

```
joerick@joerick ~/Desktop/ptywtest> node index.js
code 1
signal 0
```
