### PR TITLE
Remove all setEncoding()'s by default. UTF-8 cannot safely be implied…

### DIFF
--- a/lib/pty.js
+++ b/lib/pty.js
@@ -122,7 +122,6 @@ function Terminal(file, args, opt) {
   term = pty.fork(file, args, env, cwd, cols, rows, uid, gid, onexit);
 
   this.socket = TTYStream(term.fd);
-  this.socket.setEncoding('utf8');
   this.socket.resume();
 
   // setup
@@ -212,11 +211,9 @@ Terminal.open = function(opt) {
   term = pty.open(cols, rows);
 
   self.master = TTYStream(term.master);
-  self.master.setEncoding('utf8');
   self.master.resume();
 
   self.slave = TTYStream(term.slave);
-  self.slave.setEncoding('utf8');
   self.slave.resume();
 
   self.socket = self.master;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ptyw.js",
   "description": "Pseudo terminals for node.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "main": "./index.js",
   "repository": "git://github.com/iiegor/ptyw.js.git",

--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -44,7 +44,7 @@
 #else
 #include <util.h>
 #endif
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
 #include <libutil.h>
 #elif defined(__sun)
 #include <stropts.h> /* for I_PUSH */


### PR DESCRIPTION
…. Callers can set this explicitly, or for example set their own processing in 'data' listeners.

I had to put this in my own fork for now - non-UTF8 encodings simply fail due to explicitly setting them to UTF-8. Callers can still use setEncoding() - or, for more advanced stuff (e.g. iconv, or the like), handle it in 'data' event.
